### PR TITLE
Implementation of multiple configuration files

### DIFF
--- a/CraftyProfessions.iml
+++ b/CraftyProfessions.iml
@@ -25,15 +25,15 @@
         <SOURCES />
       </library>
     </orderEntry>
+    <orderEntry type="library" name="KotlinJavaRuntime" level="project" />
     <orderEntry type="module-library" exported="">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/../BuildTools/Spigot/Spigot-API/target/spigot-api-1.12-R0.1-SNAPSHOT-shaded.jar!/" />
+          <root url="jar://$MODULE_DIR$/../BuildTools/Spigot/Spigot-API/target/spigot-api-1.12.1-R0.1-SNAPSHOT-shaded.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES />
       </library>
     </orderEntry>
-    <orderEntry type="library" name="KotlinJavaRuntime" level="project" />
   </component>
 </module>

--- a/src/magnarisa/craftyprofessions/CraftyProfessions.java
+++ b/src/magnarisa/craftyprofessions/CraftyProfessions.java
@@ -55,7 +55,8 @@ public class CraftyProfessions extends JavaPlugin
         // Setup the Main Configuration class and likewise
         // any other needed config files, notably the WageTables.
         mConfigController = new ConfigController (this);
-        mConfigController.initilizeConfigFiles ();
+        mConfigController.createDefaultConfig ();
+        mConfigController.registerConfigFiles ();
 
         // MAKE SURE TO REMOVE THIS, TEMPORARY UNTIL WE GET THE PLAYER MANAGER/CONTROLLER
         // Setup the database and initialize the table unless it's already created.
@@ -95,7 +96,8 @@ public class CraftyProfessions extends JavaPlugin
     @Override
     public void onDisable ()
     {
-
+        this.saveConfig ();
+        mConfigController.saveConfigs ();
     }
 
     /**

--- a/src/magnarisa/craftyprofessions/CraftyProfessions.java
+++ b/src/magnarisa/craftyprofessions/CraftyProfessions.java
@@ -96,8 +96,12 @@ public class CraftyProfessions extends JavaPlugin
     @Override
     public void onDisable ()
     {
-        this.saveConfig ();
-        mConfigController.saveConfigs ();
+        /*Saving The configs will happen once the commenting yaml parser is implemented,
+        right now we will only be reading from the configs although we will eventually
+        be writing to the config files at a later date.*/
+
+        // this.saveConfig ();
+        // mConfigController.saveConfigs ();
     }
 
     /**


### PR DESCRIPTION
Implemented the use of multiple config files in order to house the WageTables within separate config files to reduce the confusion of looking at a super large config files and for clear comments that are specific to that file. I also Removed saving the configs by commenting them out. Before Beta or a stable release of the Plugin I would love to be able to write to the config files which will I will have to implement some sort of Yaml parser that implements and saves comments. This is why for now the saving of the config files will be removed and we will stick to only reading from the files to start with.