### PR TITLE
Gradle Wrapper for the Correct Version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,3 +50,7 @@ sourceSets {
 jar {
 	from configurations.compile.collect {zipTree it}
 }
+
+task wrapper(type: Wrapper) {
+	gradleVersion = '4.4.1'
+}


### PR DESCRIPTION
Updated the build.gradle to inlcude the wrapper task. Hopefully this will make gradlew build a usable command for those that don't have gradle installed. Whereas right now it is not